### PR TITLE
Add hold-to-move movement and visual orientation improvements

### DIFF
--- a/index.html
+++ b/index.html
@@ -12,13 +12,6 @@
     html,body{margin:0;height:100%;overflow:hidden;background:#0b0f14;font-family:system-ui,-apple-system,Segoe UI,Roboto,sans-serif}
     #hud{position:fixed;left:10px;top:10px;color:#e9eef6;background:rgba(0,0,0,.35);backdrop-filter:blur(8px);padding:8px 10px;border-radius:10px;font-size:12px;z-index:10}
     #err{position:fixed;left:10px;right:10px;top:10px;background:#300;color:#fff;padding:8px 10px;border-radius:10px;font-size:12px;display:none;white-space:pre-wrap;z-index:11}
-    #pad{position:fixed;left:50%;bottom:16px;transform:translateX(-50%);display:grid;grid-template-columns:60px 60px 60px;grid-template-rows:60px 60px;gap:10px;z-index:10}
-    #pad button{font-size:26px;border:none;border-radius:12px;background:rgba(255,255,255,.12);color:#e9eef6}
-    #pad button:active{transform:scale(0.96)}
-    #pad .up{grid-column:2;grid-row:1}
-    #pad .left{grid-column:1;grid-row:2}
-    #pad .down{grid-column:2;grid-row:2}
-    #pad .right{grid-column:3;grid-row:2}
     #win{position:fixed;inset:0;display:none;align-items:center;justify-content:center;background:rgba(0,0,0,.55);color:#fff;font-size:22px;text-align:center;z-index:20}
     #win div{background:rgba(0,0,0,.6);padding:16px 20px;border-radius:14px}
     #menu{position:fixed;inset:0;display:flex;align-items:center;justify-content:center;background:#0b0f14;color:#e9eef6;z-index:30;flex-direction:column;text-align:center}
@@ -45,12 +38,6 @@
   <button id="topBtn">Draufsicht</button>
   <button id="backBtn">Zurück</button>
   <button id="menuBtn">Menü</button>
-  <div id="pad">
-    <button class="up" aria-label="Vorwärts">▲</button>
-    <button class="left" aria-label="Links drehen">◀</button>
-    <button class="down" aria-label="Rückwärts">▼</button>
-    <button class="right" aria-label="Rechts drehen">▶</button>
-  </div>
   <div id="win"><div>
     <div id="winText">🎉 Geschafft!<br>Deine Zeit: <span id="finalTime"></span>s</div>
     <div id="nameEntry" style="margin-top:10px;">


### PR DESCRIPTION
## Summary
- Replace on-screen pad with hold-to-move pointer controls and drag-to-turn steering
- Show the player as a yellow marker in bird's-eye view with at least five top-view zones
- Add sky clouds and a visible sun for orientation

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68bc80272de083278bbfd3fb755386b4