### PR TITLE
Add top-view button and adjust speeds

### DIFF
--- a/index.html
+++ b/index.html
@@ -9,6 +9,8 @@
   <meta name="mobile-web-app-capable" content="yes">
   <title>FPV Labyrinth</title>
   <style>
+    *{-webkit-user-select:none;-ms-user-select:none;user-select:none}
+    input{-webkit-user-select:text;-ms-user-select:text;user-select:text}
     html,body{margin:0;height:100%;overflow:hidden;background:#0b0f14;font-family:system-ui,-apple-system,Segoe UI,Roboto,sans-serif}
     #hud{position:fixed;left:10px;top:10px;color:#e9eef6;background:rgba(0,0,0,.35);backdrop-filter:blur(8px);padding:8px 10px;border-radius:10px;font-size:12px;z-index:10}
     #err{position:fixed;left:10px;right:10px;top:10px;background:#300;color:#fff;padding:8px 10px;border-radius:10px;font-size:12px;display:none;white-space:pre-wrap;z-index:11}
@@ -20,6 +22,7 @@
     #scoreboard{margin-top:10px;text-align:left;font-size:14px}
     #timer{position:fixed;left:50%;top:10px;transform:translateX(-50%);color:#e9eef6;background:rgba(0,0,0,.35);backdrop-filter:blur(8px);padding:8px 10px;border-radius:10px;font-size:12px;z-index:10;display:none}
     #menuBtn{position:fixed;left:10px;bottom:10px;z-index:10;padding:8px 10px;border:none;border-radius:10px;background:rgba(0,0,0,.35);color:#e9eef6;font-size:12px;display:none}
+    #viewBtn{position:fixed;right:10px;bottom:10px;z-index:10;padding:8px 10px;border:none;border-radius:10px;background:rgba(0,0,0,.35);color:#e9eef6;font-size:12px;display:none}
   </style>
 </head>
 <body>
@@ -34,6 +37,7 @@
   <div id="timer"></div>
   <div id="err"></div>
   <button id="menuBtn">Menü</button>
+  <button id="viewBtn">Karte</button>
   <div id="win"><div>
     <div id="winText">🎉 Geschafft!<br>Deine Zeit: <span id="finalTime"></span>s</div>
     <div id="nameEntry" style="margin-top:10px;">


### PR DESCRIPTION
## Summary
- Increase movement speed by 30% and double rotation speed for smoother navigation.
- Enable top-view via button in easy mode and hide pads for two minutes after exiting map in medium mode.
- Disable text selection across the play area to prevent accidental highlighting.

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bcb74d3d0483279b070a1b90859fa5